### PR TITLE
adjusted the filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="styles.css"/>
     <script src="main.js" type="module" defer></script>
-    <!-- <script src="tests.js" type='module' defer></script> -->
+    <script src="tests.js" type='module' defer></script>
     <title>tUdo</title>
 </head>
 
@@ -30,7 +30,7 @@
                 </span> to mark as to do
             </p>
             <span class="nav-bar__toggle-theme--logo keyboard-navigable" tabindex="0">&#9728</span>
-            <span class="nav-bar__toggle-completed--logo keyboard-navigable" tabindex="0">&#9744;</span>
+            <span id="toggle-filter" class="nav-bar__filter keyboard-navigable" tabindex="0">&#9744;</span>
         </nav>
     </header>
     <main class="width-large center">

--- a/main.js
+++ b/main.js
@@ -14,14 +14,13 @@ const taskCollection = new TaskCollection();
 //     console.log(`Description: ${task.description}, Status: ${task.getStatusText()}`);
 // });
 
-let showCompletedTasks = true;
 const canvas = document.querySelector("#canvas");
 const infoButton = document.querySelector(".nav-bar");
 const toggleThemeButton = document.querySelector(
   ".nav-bar__toggle-theme--logo"
 );
-const toggleCompletedTasksButton = document.querySelector(
-  ".nav-bar__toggle-completed--logo"
+const toggleFilter = document.querySelector(
+  ".nav-bar__filter"
 );
 
 // Disable context menu on nav-bar
@@ -31,8 +30,8 @@ toggleThemeButton.addEventListener("click", (e) => {
   toggleTheme(e);
 });
 // Set up toggle show/hide completed tasks event handler
-toggleCompletedTasksButton.addEventListener("click", (e) => {
-  toggleCompletedTasks(e);
+toggleFilter.addEventListener("click", (e) => {
+  toggleCompletedTasks();
 });
 
 
@@ -58,34 +57,35 @@ const printHTML = (input) => {
 const newItem = (object) => {
   let { description, status } = object;
   let checkedItem = status === TaskStatus.Complete ? "checked=true" : "";
-
+  
   let newTask = printHTML(`
-    <div class='item width-large'>
-      <input type='checkbox' class='item__completed' ${checkedItem}</input>
-      <input type="text" class='item__description' placeholder='add item ...'></input>
-    </div>
-    `);
+  <div class='item width-large'>
+  <input type='checkbox' class='item__completed' ${checkedItem}</input>
+  <input type="text" class='item__description' placeholder='add item ...'></input>
+  </div>
+  `);
   canvas.append(newTask);
-
+  
   let textInput = newTask.querySelector(".item__description");
   textInput.value = description;
 };
 
 // initialise the page /////////////////////
 ///////////////////////////////////////////
-function renderTaskList(showCompleted = true) {
+function renderTaskList() {
   canvas.innerHTML = "";
   newItem({ description: "" });
   let emptyTask = document.querySelector(".item__description");
   emptyTask.addEventListener("keyup", (e) => enterNewItem(e, emptyTask));
-
-
-  taskCollection.getAllTasksFromStorage(showCompleted);
-
+  
+  
+  taskCollection.getAllTasksFromStorage();
+  
   for (let i = 0; i < taskCollection.allTasks.length; i++) {
     newItem(taskCollection.allTasks[i]);
   }
   listenForKeyStrokes();
+  filterItemsOnPage()
 }
 
 // keyboard commands ////////////////////////
@@ -104,115 +104,128 @@ function enterNewItem(keyPress, activeElement) {
 function deleteItem(edited) {
   let items = Array.from(
     document.querySelectorAll(".item__description")
-  ).splice(1);
-  let index = items.indexOf(edited);
-  taskCollection.deleteTask(index);
-  renderTaskList();
-}
-
-function editItem(edited) {
-  let items = Array.from(
-    document.querySelectorAll(".item__description")
-  ).splice(1);
-  let index = items.indexOf(edited);
-  let newDescription = edited.value;
-  let newStatus = edited.parentElement.firstElementChild.checked ? 2 : 1;
-
-  taskCollection.editTask(index, newDescription, newStatus);
-  renderTaskList();
-}
-
-function tickItem(edited) {
-  let checkBox = edited.previousElementSibling;
-  checkBox.checked = true;
-  edited.value = edited.value.replace(/(\/done)$/, "");
-  editItem(edited);
-}
-
-function untickItem(edited) {
-  let checkBox = edited.previousElementSibling;
-  checkBox.checked = false;
-  edited.value = edited.value.replace(/(\/pending)$/, "");
-  editItem(edited);
-}
-
-function makeButtonActive(button){
-  button.classList.toggle('nav-bar__info-logo--active');
-  button.blur();
-}
-
-// listen for User Input //////////////////////////
-///// all event listeners can be stored here //////
-function listenForKeyStrokes() {
-  // listen for keyboard input
-  let tasksOnPage = Array.from(
-    document.querySelectorAll(".item__description")
-  ).splice(1);
-
-  let typeToDelete = new RegExp(/(\/delete)$/);
-  let typeToComplete = new RegExp(/(\/done)$/);
-  let typeToUntick = new RegExp(/(\/pending)$/);
-
-  tasksOnPage.forEach((task) => {
-    task.addEventListener("keyup", (e) => {
-      if (e.key !== "Enter") return;
-      if (typeToDelete.test(task.value)) return deleteItem(task);
-      if (typeToComplete.test(task.value)) return tickItem(task);
-      if (typeToUntick.test(task.value)) return untickItem(task);
-      editItem(task);
-    });
-  });
-
-  // listen for checkbox interaction
-  let checkBoxes = Array.from(
-    document.querySelectorAll(".item__completed")
-  ).splice(1);
-
-  checkBoxes.forEach((box) => {
-    box.addEventListener("change", () => {
-      let index = checkBoxes.indexOf(box);
-      let newDescription = box.nextElementSibling.value;
-      let newStatus = box.checked === true ? 2 : 1;
-
+    ).splice(1);
+    let index = items.indexOf(edited);
+    taskCollection.deleteTask(index);
+    renderTaskList();
+  }
+  
+  function editItem(edited) {
+    let items = Array.from(
+      document.querySelectorAll(".item__description")
+      ).splice(1);
+      let index = items.indexOf(edited);
+      let newDescription = edited.value;
+      let newStatus = edited.parentElement.firstElementChild.checked ? 2 : 1;
+      
       taskCollection.editTask(index, newDescription, newStatus);
-    });
-  });
-
-  //listen for navbar interaction
-  let infoButton = document.querySelector('.nav-bar__info-logo');
-  infoButton.addEventListener('click', () => makeButtonActive(infoButton));
-}
-
-function toggleTheme(event) {
-  const element = event.srcElement;
-  const bodyElement = document.querySelector("body");
-
-  const currentTheme = bodyElement.getAttribute("data-theme");
-
-  if (currentTheme === "light") {
-    element.innerHTML = "&#9728";
-    bodyElement.setAttribute("data-theme", "dark");
-  } else {
-    element.innerHTML = "&#9790";
-    bodyElement.setAttribute("data-theme", "light");
-  }
-}
-
-function toggleCompletedTasks(event) {
-  const element = event.srcElement;
-
-  if (showCompletedTasks) {
-    element.innerHTML = "&#9745";
-    renderTaskList(false);
-  } else {
-    element.innerHTML = "&#9744";
-    renderTaskList();  // <<<<------------------- THIS IS IN THE WRONG PLACE TO WORK
-  }
-  showCompletedTasks = !showCompletedTasks;
-}
-
-// initialise the page ///////////////////////
-/////////////////////////////////////////////
-
-renderTaskList();
-
+      renderTaskList();
+    }
+    
+    function tickItem(edited) {
+      let checkBox = edited.previousElementSibling;
+      checkBox.checked = true;
+      edited.value = edited.value.replace(/(\/done)$/, "");
+      editItem(edited);
+    }
+    
+    function untickItem(edited) {
+      let checkBox = edited.previousElementSibling;
+      checkBox.checked = false;
+      edited.value = edited.value.replace(/(\/pending)$/, "");
+      editItem(edited);
+    }
+    
+    function makeButtonActive(button){
+      button.classList.toggle('nav-bar__info-logo--active');
+      button.blur();
+    }
+    
+    function filterItemsOnPage(){
+      let tasksOnPage = document.querySelectorAll('.item');
+      let isFilterOn = document.getElementById('toggle-filter').classList.contains('nav-bar__filter--active') ? true : false;
+      tasksOnPage.forEach(task => {
+        if (isFilterOn) return task.classList.add('item--filtered-out');
+        task.classList.remove('item--filtered-out');
+      });
+    }
+    
+    function turnFilterOff(){
+      let filterButton = document.getElementById('toggle-filter');
+      filterButton.classList.remove('nav-bar__filter--active');
+      filterButton.innerHTML = "&#9745";
+      filterItemsOnPage();
+    }
+    
+    function turnFilterOn(){
+      let filterButton = document.getElementById('toggle-filter');
+      filterButton.classList.add('nav-bar__filter--active');
+      filterButton.innerHTML = "&#9744";
+      filterItemsOnPage();
+    }
+    
+    // listen for User Input //////////////////////////
+    ///// all event listeners can be stored here //////
+    function listenForKeyStrokes() {
+      // listen for keyboard input
+      let tasksOnPage = Array.from(
+        document.querySelectorAll(".item__description")
+        ).splice(1);
+        
+        let typeToDelete = new RegExp(/(\/delete)$/);
+        let typeToComplete = new RegExp(/(\/done)$/);
+        let typeToUntick = new RegExp(/(\/pending)$/);
+        
+        tasksOnPage.forEach((task) => {
+          task.addEventListener("keyup", (e) => {
+            if (e.key !== "Enter") return;
+            if (typeToDelete.test(task.value)) return deleteItem(task);
+            if (typeToComplete.test(task.value)) return tickItem(task);
+            if (typeToUntick.test(task.value)) return untickItem(task);
+            editItem(task);
+          });
+        });
+        
+        // listen for checkbox interaction
+        let checkBoxes = Array.from(
+          document.querySelectorAll(".item__completed")
+          ).splice(1);
+          
+          checkBoxes.forEach((box) => {
+            box.addEventListener("change", () => {
+              let index = checkBoxes.indexOf(box);
+              let newDescription = box.nextElementSibling.value;
+              let newStatus = box.checked === true ? 2 : 1;
+              
+              taskCollection.editTask(index, newDescription, newStatus);
+            });
+          });
+          
+          //listen for navbar interaction
+          let infoButton = document.querySelector('.nav-bar__info-logo');
+          infoButton.addEventListener('click', () => makeButtonActive(infoButton));
+        }
+        
+        function toggleTheme(event) {
+          const element = event.srcElement;
+          const bodyElement = document.querySelector("body");
+          
+          const currentTheme = bodyElement.getAttribute("data-theme");
+          
+          if (currentTheme === "light") {
+            element.innerHTML = "&#9728";
+            bodyElement.setAttribute("data-theme", "dark");
+          } else {
+            element.innerHTML = "&#9790";
+            bodyElement.setAttribute("data-theme", "light");
+          }
+        }
+        
+        function toggleCompletedTasks() {
+          let isFilterOn = document.getElementById('toggle-filter').classList.contains('nav-bar__filter--active') ? true : false;
+          isFilterOn ? turnFilterOff() : turnFilterOn();
+        }
+        
+        // initialise the page ///////////////////////
+        /////////////////////////////////////////////
+        renderTaskList();

--- a/styles.css
+++ b/styles.css
@@ -55,7 +55,14 @@ body {
   user-select: none;
 }
 
-.nav-bar__toggle-completed--logo {
+.nav-bar__filter {
+  font-size: 1.5rem;
+  cursor: pointer;
+  user-select: none;
+  
+}
+
+.nav-bar__filter--active{
   font-size: 1.5rem;
   cursor: pointer;
   user-select: none;
@@ -109,6 +116,10 @@ display: block;
   align-items: center;
   width: 100%;
   grid-column: 2 / span 4;
+}
+
+.item--filtered-out:has(.item__completed:checked) {
+  display:none;
 }
 
 .item__completed {

--- a/tests.js
+++ b/tests.js
@@ -135,4 +135,4 @@ function runTests(){
     }
 }
 
-runTests()
+test('all tasks are on the page', trackTaskListInStorage)


### PR DESCRIPTION
This is a completely different setup, so if you see a solution with the option you had we can absolutely go for that, but I honestly kept coming to this.

When I started testing the filter I found a few issues that came from the fact that when we make changes to an item we render the page again, and the solution you had created would lead to a few tasks vanishing.
- tasks filtered would vanish if you made changes to an item and then toggled the filter off again
- tasks marked as done while the filter was off would not be affected until you toggled the filter off and on again, triggering the bug in the first point

I went around this by creating a function that checks whether the filter button is in the active state or not (this isn't affected when we render the task list again) then the code changed the actual button depending on it's current state and runs through all tasks to assign to them a class modifier of '--filtered-out'.

Because this is split into small functions we can recheck the state of the filter and action all the tasks (without changing the button) whenever we render the task list after any alterations.

With these changes:
- the filter affects new tasks that are marked as complete while it's turned on
- the number of tasks rendered is always equal to the number of tasks stored (which keeps the other functions from editing the wrong index in the list)
- the page remembers the state of the filter when you change things, unless we actually reload the page